### PR TITLE
feat: ios app store link

### DIFF
--- a/frontend/assets/lang/ca.json
+++ b/frontend/assets/lang/ca.json
@@ -1,6 +1,7 @@
 {
     "google_play_badge_url": "https://play.google.com/intl/ca_ES/badges/static/images/badges/ca_badge_web_generic.png",
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-ca.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/ca-es",
     "btn_decrypt": "Desxifrar",
     "btn_cancel": "Cancel·la",
     "btn_dismiss": "Rebutjar",

--- a/frontend/assets/lang/de.json
+++ b/frontend/assets/lang/de.json
@@ -1,6 +1,7 @@
 {
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on.png",
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/de_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/de-de",
     "btn_dismiss": "Verwerfen",
     "status_offline": "Offline",
     "status_expired": "Abgelaufen",

--- a/frontend/assets/lang/en.json
+++ b/frontend/assets/lang/en.json
@@ -32,5 +32,7 @@
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on.png",
     "f_droid_badge_text": "Get it on F-Droid",
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png",
-    "google_play_badge_text": "Get it on Google Play"
+    "google_play_badge_text": "Get it on Google Play",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/en-us",
+    "app_store_badge_text": "Download on the App Store"
 }

--- a/frontend/assets/lang/fr.json
+++ b/frontend/assets/lang/fr.json
@@ -13,6 +13,7 @@
     "expired_head": "Localisation expirée",
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-fr.png",
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/fr_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/fr-fr",
     "e2e_password_prompt": "Ce partage est protégé par un mot de passe. Entrez le mot de passe pour y accéder.",
     "google_play_badge_text": "Installer par Google Play",
     "f_droid_badge_text": "Installer par F-Droid",

--- a/frontend/assets/lang/it.json
+++ b/frontend/assets/lang/it.json
@@ -1,6 +1,7 @@
 {
     "google_play_badge_text": "Disponibile su Google Play",
     "google_play_badge_url": "https://play.google.com/intl/it_it/badges/static/images/badges/it_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/it-it",
     "f_droid_badge_text": "Disponibile su F-Droid",
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-it.png",
     "btn_show_all": "Mostra tutto",

--- a/frontend/assets/lang/ko.json
+++ b/frontend/assets/lang/ko.json
@@ -2,6 +2,7 @@
     "btn_dismiss": "닫기",
     "google_play_badge_text": "Google Play 에서 다운로드",
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/ko_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/ko-kr",
     "f_droid_badge_text": "F-Droid 에서 다운로드",
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-ko.png",
     "btn_show_all": "모두 보기",

--- a/frontend/assets/lang/nb_NO.json
+++ b/frontend/assets/lang/nb_NO.json
@@ -1,6 +1,7 @@
 {
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-no.png",
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/no_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/no-no",
     "btn_dismiss": "Lukk",
     "status_offline": "Frakoblet",
     "status_expired": "Utløpt",

--- a/frontend/assets/lang/nl.json
+++ b/frontend/assets/lang/nl.json
@@ -2,6 +2,7 @@
     "dialog_expired_body": "De locatiedeling is verlopen.",
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-nl.png",
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/nl_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/nl-nl",
     "btn_dismiss": "Sluiten",
     "status_offline": "Offline",
     "status_expired": "Verlopen",

--- a/frontend/assets/lang/nn.json
+++ b/frontend/assets/lang/nn.json
@@ -1,6 +1,7 @@
 {
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-no.png",
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/no_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/no-no",
     "btn_dismiss": "Lukk",
     "status_offline": "Fråkopla",
     "status_expired": "Gått ut",

--- a/frontend/assets/lang/pl.json
+++ b/frontend/assets/lang/pl.json
@@ -1,6 +1,7 @@
 {
     "google_play_badge_text": "Pobierz z Google Play",
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/pl_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/pl-pl",
     "f_droid_badge_text": "Pobierz z F-Droid",
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-pl.png",
     "btn_show_all": "Pokaż wszystko",

--- a/frontend/assets/lang/pt_BR.json
+++ b/frontend/assets/lang/pt_BR.json
@@ -32,5 +32,6 @@
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-pt-br.png",
     "f_droid_badge_text": "Obtê-lo no F-Droid",
     "google_play_badge_url": "https://play.google.com/intl/pt_br/badges/static/images/badges/pt_badge_web_generic.png",
-    "google_play_badge_text": "Obtê-lo no Google Play"
+    "google_play_badge_text": "Obtê-lo no Google Play",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/pt-br"
 }

--- a/frontend/assets/lang/ro.json
+++ b/frontend/assets/lang/ro.json
@@ -9,6 +9,7 @@
     "btn_dismiss": "Revocare",
     "dialog_connection_head": "Eroare de conexiune",
     "google_play_badge_url": "https://play.google.com/intl/ro_ro/badges/static/images/badges/ro_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/ro-ro",
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-ro.png",
     "btn_decrypt": "Deblocare",
     "last_update_days": "Acum {{time}}z",

--- a/frontend/assets/lang/ru.json
+++ b/frontend/assets/lang/ru.json
@@ -1,6 +1,7 @@
 {
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-ru.png",
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/ru_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/ru-ru",
     "btn_dismiss": "Отменить",
     "status_offline": "Не подключено",
     "status_expired": "Истекло",
@@ -17,6 +18,7 @@
     "btn_cancel": "Отмена",
     "e2e_placeholder": "Введите пароль",
     "google_play_badge_text": "Установить из Google Play",
+    "app_store_badge_text": "Загрузите в App Store",
     "btn_show_all": "Показать все",
     "btn_close": "Закрыть",
     "last_update_days": "был {{time}} дней назад",

--- a/frontend/assets/lang/tr.json
+++ b/frontend/assets/lang/tr.json
@@ -3,6 +3,7 @@
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/tr_badge_web_generic.png",
     "f_droid_badge_text": "F-Droid'den alın",
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-tr.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/tr-tr",
     "btn_show_all": "Hepsini göster",
     "btn_close": "Kapat",
     "btn_decrypt": "Kilidi aç",

--- a/frontend/assets/lang/uk.json
+++ b/frontend/assets/lang/uk.json
@@ -1,6 +1,8 @@
 {
     "f_droid_badge_url": "https://fdroid.gitlab.io/artwork/badge/get-it-on-ua.png",
     "google_play_badge_url": "https://play.google.com/intl/en_us/badges/static/images/badges/ua_badge_web_generic.png",
+    "app_store_badge_url": "https://toolbox.marketingtools.apple.com/api/v2/badges/download-on-the-app-store/black/uk-ua",
+    "app_store_badge_text": "Завантажити в App Store",
     "btn_dismiss": "Відмінити",
     "status_offline": "Офлайн",
     "status_expired": "Термін дії закінчився",

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -76,6 +76,12 @@
                      data-i18n-attr="alt"
                      class="store-icon"
                      id="store-icon-gplay">
+            </a>
+            <a href="https://apps.apple.com/app/id6738009304">
+                <img data-i18n="app_store_badge_text"
+                     data-i18n-attr="alt"
+                     class="store-icon"
+                     id="store-icon-appstore">
             </a></p>
         </div>
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -82,10 +82,12 @@ function init() {
         var indexE = document.getElementById("index");
         var storeIconFdroidE = document.getElementById("store-icon-fdroid");
         var storeIconGplayE = document.getElementById("store-icon-gplay");
+        var storeIconAppstoreE = document.getElementById("store-icon-appstore");
         if (urlE !== null) urlE.textContent = url;
         if (indexE !== null) indexE.style.display = "block";
         if (storeIconFdroidE !== null) storeIconFdroidE.src = LANG["f_droid_badge_url"];
         if (storeIconGplayE !== null) storeIconGplayE.src = LANG["google_play_badge_url"];
+        if (storeIconAppstoreE !== null) storeIconAppstoreE.src = LANG["app_store_badge_url"];
     } else {
         // Attempt to fetch location data from the server once.
         getJSON("./api/fetch.php?id=" + id, function(data) {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -122,15 +122,21 @@ body {
     font-family: monospace;
     font-size: 5vmin;
 }
-.store-icon {
-    margin-top: 1vmin;
-    width: 40vmin;
+.cover#index a {
+    text-decoration: none;
+}
+.store-icon:not(#store-icon-appstore) {
+    width: 29vmin;
+    margin-right: -2vmin;
+}
+.store-icon#store-icon-appstore {
+    width: 23vmin;
+    margin-bottom: 1.7vmin;
+    margin-left: 1.7vmin;
+    margin-top: 1.7vmin;
 }
 a:first-child > .store-icon {
-    margin-left: -5vmin;
-}
-a:last-child > .store-icon {
-    margin-right: -5vmin;
+    margin-left: -2vmin;
 }
 
 /* Display the Hauk logo in the bottom left corner of the map if the viewport is


### PR DESCRIPTION
Hi!

Not sure it's a good idea, but why not.

I use @NickBouwhuis's iOS app with go-hauk as backend. It works fine. Just want it to be mentioned on the index page of go-hauk along oringinal android hauk app. 

Here is the repo: https://github.com/NickBouwhuis/hauk-ios
And the app store link: https://apps.apple.com/app/id6738009304

I'm not good at CSS, and Apple's 'Download on the App Store' badge have different dimensions than badges for Google Play and F-Droid. I tried my best to make it look good and to preserve original hauk's square vmin-based layout, introduced few more magic numbers, but it's not pixel perfect and the buttons may look too small on mobile devices.


I didn't build the whole go app to test this, just served static frontend files locally like this:
```
user@machine:go-hauk/frontend$ python3 -m http.server
```
I guess there is no difference for the index page.